### PR TITLE
Just a quick update to make the hideable graph labels work more nicely with the GoFaster dashboard (and similar single-page apps)

### DIFF
--- a/jquery.flot.hiddengraphs.js
+++ b/jquery.flot.hiddengraphs.js
@@ -187,7 +187,7 @@
                 }
                 var labelLink = '<span class="graphlabel">' + labelText;
                 if (button) {
-                    labelLink += '<a class="graphlabellink" href="#">' + button + '</a>';
+                    labelLink += '<a class="graphlabellink" style="cursor:pointer;">' + button + '</a>';
                 }
                 labelLink += '</span>';
                 return labelLink;


### PR DESCRIPTION
Linking to '#' can mess up single-page applications which are using
the bookmarked part of the URL for other purposes.
