### PR TITLE
fix for supporting real-time graph updates. 

### DIFF
--- a/jquery.flot.hiddengraphs.js
+++ b/jquery.flot.hiddengraphs.js
@@ -38,9 +38,9 @@
  */
 (function ($) {
     var options = { };
-    var drawnOnce = false;
 
     function init(plot) {
+        var drawnOnce = false;
     	
         function findPlotSeries(label) {
             var plotdata = plot.getData();
@@ -127,7 +127,9 @@
             if (!options.legend.hideable) {
                 return;
             }
-            $(".graphlabel").mouseenter(function() { $(this).css("cursor", "pointer"); })
+            // look for the label under the current plot to support multiple graphs
+            var p = plot.getPlaceholder();
+            p.find(".graphlabel").mouseenter(function() { $(this).css("cursor", "pointer"); })
             .mouseleave(function() { $(this).css("cursor", "default"); })
             .unbind("click").click(function() { plotLabelClicked($(this).parent().text()); });
 


### PR DESCRIPTION
This fix handles an issue with updating the graph data. When you do real-time graph updates the hidden state (the fields added under the points) is "forgotten" (since the points object is updated). 

To handle it I'm added the hidden series to the "hidden" array under the options. This is not re-written when you update the data so the state is kept between updates. 

There's also a small fix inside to handle multiple plots on the same page.
