### PR TITLE
Add support for hiding when clicking colored square

### DIFF
--- a/jquery.flot.hiddengraphs.js
+++ b/jquery.flot.hiddengraphs.js
@@ -105,6 +105,9 @@
             $(".graphlabel").mouseenter(function() { $(this).css("cursor", "pointer"); })
                             .mouseleave(function() { $(this).css("cursor", "default"); })
                             .unbind("click").click(function() { plotLabelClicked($(this).parent().text()); });
+	    $(".legendColorBox").mouseenter(function() { $(this).css("cursor", "pointer"); })
+		    		.mouseleave(function() { $(this).css("cursor", "default"); })
+				.unbind("click").click(function() { plotLabelClicked($(this).parent().text()); });
             if (!drawnOnce) {
                 drawnOnce = true;
                 if (options.legend.hidden) {


### PR DESCRIPTION
This pull request adds support for showing/hiding the series when clicking on the corresponding colored square in the legend.
