### PR TITLE
Deffered refershing chart after hidding series

### DIFF
--- a/jquery.flot.hiddengraphs.js
+++ b/jquery.flot.hiddengraphs.js
@@ -103,11 +103,21 @@
             	}
             }
 
-            // HACK: Reset the data, triggering recalculation of graph bounds
-            plot.setData(plot.getData());
-
-            plot.setupGrid();
-            plot.draw();
+            // HACK: Reset the data, triggering recalculation of graph bounds                      
+            drawDeffered(series);            
+        }
+        
+        function drawDeffered(series) {            
+            if(drawTimeout) {
+                return;
+            }
+            drawTimeout = setTimeout(function() {
+                onHide(series, plot);
+                plot.setData(plot.getData());
+                plot.setupGrid();
+                plot.draw();
+                drawTimeout = 0;
+            }, 0);
         }
 
         function setHidden(options, label, hide) {

--- a/jquery.flot.hiddengraphs.js
+++ b/jquery.flot.hiddengraphs.js
@@ -104,15 +104,14 @@
             }
 
             // HACK: Reset the data, triggering recalculation of graph bounds                      
-            drawDeffered(series);            
+            drawDeffered();            
         }
         
-        function drawDeffered(series) {            
+        function drawDeffered() {            
             if(drawTimeout) {
                 return;
             }
             drawTimeout = setTimeout(function() {
-                onHide(series, plot);
                 plot.setData(plot.getData());
                 plot.setupGrid();
                 plot.draw();


### PR DESCRIPTION
When hidden param is used in initial config, for every series it calls:
plot.setData(plot.getData());
plot.setupGrid();
plot.draw();
which is quite costly for e.g. more than 10 series. To avoid this behavior, we can deffer this calls so it runs only once after all series have been hidden.
