### PR TITLE
Support the 'container' property of flot legends.

### DIFF
--- a/jquery.flot.hiddengraphs.js
+++ b/jquery.flot.hiddengraphs.js
@@ -151,10 +151,15 @@
                 return;
             }
 
-            var p = plot.getPlaceholder();
-
+            if ((typeof options.legend.container === 'object') && (options.legend.container !== null)) {
+                var p = $(options.legend.container);
+            }
+            else {
+                var p = plot.getPlaceholder();
+            }
             setHideAction(p.find(".graphlabel"));
             setHideAction(p.find(".legendColorBox"));
+
 
             if (!drawnOnce) {
                 drawnOnce = true;


### PR DESCRIPTION
Thanks for your plugin.

It infortunately does not work out of the box when the flot legend is set outside the drawing zone (using the `container` property).  This patch fixes it.
